### PR TITLE
Clean up sass import

### DIFF
--- a/lib/cli/init/template/assets/scss/app.scss
+++ b/lib/cli/init/template/assets/scss/app.scss
@@ -1,4 +1,4 @@
-@import "hof-frontend-toolkit/assets/stylesheets/app.scss";
+@import "hof-frontend-toolkit";
 
 .phase-banner {
   @include phase-banner(beta);

--- a/lib/cli/init/template/package.json
+++ b/lib/cli/init/template/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "hof-bootstrap": "^9.0.0",
     "hof-controllers": "^6.0.1",
-    "hof-frontend-toolkit": "^1.0.0",
+    "hof-frontend-toolkit": "^1.0.1",
     "hof-template-partials": "^3.2.0",
     "hof-transpiler": "^0.2.0"
   },


### PR DESCRIPTION
The newer version of hof-frontend-toolkit defines the location of its core sass file in package.json so doesn't need to be defined here.