### PR TITLE
"Fix" spelling of license in package.json

### DIFF
--- a/lib/cli/init/template/package.json
+++ b/lib/cli/init/template/package.json
@@ -1,5 +1,5 @@
 {
-  "licence": "MIT",
+  "license": "MIT",
   "scripts": {
     "start": "node app.js",
     "test": "npm run test:lint",


### PR DESCRIPTION
"license" field uses (incorrect) American spelling, which means it ends up with a ISC "license" and an MIT "licence" after running generator.