### PR TITLE
Move npm sass to full dependency

### DIFF
--- a/lib/cli/init/template/package.json
+++ b/lib/cli/init/template/package.json
@@ -17,12 +17,12 @@
     "hof-controllers": "^6.0.1",
     "hof-frontend-toolkit": "^1.0.1",
     "hof-template-partials": "^3.2.0",
-    "hof-transpiler": "^0.2.0"
+    "hof-transpiler": "^0.2.0",
+    "npm-sass": "^1.3.0"
   },
   "devDependencies": {
     "browserify": "^13.3.0",
     "eslint": "^3.14.0",
-    "eslint-config-homeoffice": "^2.1.0",
-    "npm-sass": "^1.3.0"
+    "eslint-config-homeoffice": "^2.1.0"
   }
 }


### PR DESCRIPTION
The way we deploy into docker means this need to be a full dependency to be able to compile css on deployments.