### PR TITLE
Stop generating session secrets

### DIFF
--- a/lib/cli/init/defaults.js
+++ b/lib/cli/init/defaults.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const crypto = require('crypto');
-
 module.exports = {
   force: false,
-  app: 'default-app',
-  secret: crypto.randomBytes(64).toString('hex')
+  app: 'default-app'
 };

--- a/lib/cli/init/template/hof.settings.tpl.json
+++ b/lib/cli/init/template/hof.settings.tpl.json
@@ -1,7 +1,6 @@
 {
   "routes": [],
   "session": {
-    "name": "{{dirname}}.hof.sid",
-    "secret": "{{secret}}"
+    "name": "{{dirname}}.hof.sid"
   }
 }


### PR DESCRIPTION
Since the code generated will be checked into version control it should not contain any secret keys.