### PR TITLE
Use the name of the directory as a default app name

### DIFF
--- a/lib/cli/init/defaults.js
+++ b/lib/cli/init/defaults.js
@@ -1,6 +1,5 @@
 'use strict';
 
 module.exports = {
-  force: false,
-  app: 'default-app'
+  force: false
 };

--- a/lib/cli/init/index.js
+++ b/lib/cli/init/index.js
@@ -17,10 +17,11 @@ function init(dir, options) {
   dir = dir || '.';
   dir = path.resolve(process.cwd(), dir);
 
-  const settings = Object.assign({}, defaults, options, {
+  const settings = Object.assign({}, defaults, {
     dir,
-    dirname: path.basename(dir)
-  });
+    dirname: path.basename(dir),
+    app: path.basename(dir)
+  }, options);
   const root = path.resolve(__dirname, './tasks');
   return chain(tasks, root, settings)
     .then(() => {


### PR DESCRIPTION
`default-app` is a bad default because it will never be actually used. Instead the current directory name is likely going to be a useful default value.