### PR TITLE
Remove redundant views directory

### DIFF
--- a/lib/cli/app/template/views/step.html
+++ b/lib/cli/app/template/views/step.html
@@ -1,8 +1,0 @@
-{{<partials-page}}
-  {{$page-content}}
-    {{#fields}}
-      {{#renderField}}{{/renderField}}
-    {{/fields}}
-    {{#input-submit}}continue{{/input-submit}}
-  {{/page-content}}
-{{/partials-page}}


### PR DESCRIPTION
hof-bootstrap no longer mandates a views directory to exist in the app, and so there's no need to generate this file.