### PR TITLE
Remove redundant mixin property

### DIFF
--- a/lib/cli/app/template/fields/index.js
+++ b/lib/cli/app/template/fields/index.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   name: {
-    mixin: 'input-text',
     validate: 'required'
   }
 };


### PR DESCRIPTION
Fields are text fields by default. They don't need to be specified and make it simpler to configure if they're not.