### PR TITLE
Use npm start to run app in docker

### DIFF
--- a/lib/cli/init/template/Dockerfile
+++ b/lib/cli/init/template/Dockerfile
@@ -10,4 +10,5 @@ RUN yum clean all && \
 
 COPY . /app
 
-CMD node /app/app.js
+CMD cd /app
+CMD npm start


### PR DESCRIPTION
This ensures that the prestart transpile step runs in all contexts. It currently doesn't if you run docker.