### PR TITLE
Add a spinner to console output

### DIFF
--- a/lib/cli/init/tasks/install-dependencies.js
+++ b/lib/cli/init/tasks/install-dependencies.js
@@ -15,5 +15,8 @@ module.exports = function install(settings) {
           resolve();
         }
       });
+    if (settings.verbose) {
+      settings.spinner.stopAndPersist();
+    }
   });
 };

--- a/lib/utils/chain.js
+++ b/lib/utils/chain.js
@@ -2,14 +2,21 @@
 
 const Promise = require('bluebird');
 const path = require('path');
+const ora = require('ora');
 
 function chain(tasks, root, settings) {
   return tasks.reduce((p, task) => {
     return p
       .then(() => {
-        console.log(`Executing task: ${task}`);
+        settings.spinner = ora(`Executing task: ${task}`).start();
         const fn = require(path.resolve(root, task));
-        return fn(settings);
+        return fn(settings)
+          .then(() => {
+            settings.spinner.succeed();
+          }, e => {
+            settings.spinner.fail();
+            throw e;
+          });
       });
   }, Promise.resolve());
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash.some": "^4.6.0",
     "mkdirp": "^0.5.1",
     "mu2": "^0.5.21",
+    "ora": "^1.2.0",
     "update-notifier": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Install phase can take a while, so adding a spinner can help user confidence that it hasn't crashed out.