### PR TITLE
Fix regex for template files

### DIFF
--- a/lib/utils/copy.js
+++ b/lib/utils/copy.js
@@ -14,7 +14,7 @@ function compile(src, dest, settings) {
     .then(() => {
       return new Promise((resolve, reject) => {
         let stream;
-        if (path.basename(src).match(/\.tpl\./)) {
+        if (path.basename(src).match(/\.tpl(\.|$)/)) {
           dest = dest.replace('.tpl', '');
           stream = mu.compileAndRender(src, settings);
         } else {


### PR DESCRIPTION
The regex wasn't matching dotfiles with no file extension so modify it to also include .tpl files with no additional extension.