### PR TITLE
Prevent lockfile creation on theme install with npm@5

### DIFF
--- a/lib/cli/init/tasks/install-theme.js
+++ b/lib/cli/init/tasks/install-theme.js
@@ -3,5 +3,5 @@
 const installer = require('./install-dependencies');
 
 module.exports = function install(settings) {
-  return installer(settings, ['--save', `hof-theme-${settings.theme}`]);
+  return installer(settings, ['--save', `hof-theme-${settings.theme}`, '--no-shrinkwrap']);
 };


### PR DESCRIPTION
npm@5 was creating a lock file when the theme was installed that then prevented dependencies being properly installed on the subsequent call to `npm install`.

By passing a `--no-shrinkwrap` flag the creation of an initial package-lock.json file is prevented and the subsequent `npm install` installs correctly.