### PR TITLE
Move app build to before install step

### DIFF
--- a/lib/cli/init/index.js
+++ b/lib/cli/init/index.js
@@ -7,11 +7,11 @@ const chain = require('../../utils/chain');
 const tasks = [
   'check-empty',
   'copy-files',
+  'create-app',
   'add-gitignore',
   'npm-init',
   'install-theme',
-  'install-dependencies',
-  'create-app'
+  'install-dependencies'
 ];
 
 function init(dir, options) {


### PR DESCRIPTION
The translations are compiled at `postinstall`, but they don't exist by then because the app is created later. Instead move the app creation phase to before "install" so all assets are correctly in place.