### PR TITLE
Ensure file modes are preserved when copying files

### DIFF
--- a/lib/utils/copy.js
+++ b/lib/utils/copy.js
@@ -12,6 +12,14 @@ function compile(src, dest, settings) {
   settings = settings || {};
   return mkdirp(path.dirname(dest))
     .then(() => {
+      // read the file mode of the source file
+      return new Promise((resolve, reject) => {
+        fs.stat(src, (err, stat) => {
+          return err ? reject(err) : resolve(stat.mode);
+        });
+      });
+    })
+    .then(mode => {
       return new Promise((resolve, reject) => {
         let stream;
         if (path.basename(src).match(/\.tpl(\.|$)/)) {
@@ -20,7 +28,7 @@ function compile(src, dest, settings) {
         } else {
           stream = fs.createReadStream(src);
         }
-        stream.pipe(fs.createWriteStream(dest));
+        stream.pipe(fs.createWriteStream(dest, { mode }));
         stream.on('end', resolve);
         stream.on('error', reject);
       });


### PR DESCRIPTION
In particular, when run.sh is copied from the template it was losing its `+x` executable permissions. To resolve, read the file mode of source files before copying and ensure they are written when writing the files to the destination directory.

Fixes https://github.com/UKHomeOfficeForms/hof/issues/156