### PR TITLE
Hof-17: Update hof package to 17

### DIFF
--- a/lib/cli/init/template/package.json
+++ b/lib/cli/init/template/package.json
@@ -9,7 +9,7 @@
     "postinstall": "npm run build"
   },
   "dependencies": {
-    "hof": "^12.0.0",
+    "hof": "^17.0.2",
     "hof-behaviour-summary-page": "^2.0.0",
     "hof-build": "^1.3.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-generator",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "CLI to quickly generate the file and folder structure for a basic hof app",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## What?
Update the generator to install hof 17, which is the latest
## Why?
Because it was installing 12 and that is ancient mate

## Anything Else?
* I wasn't able to test it but I'm sure it will work but no production issues if it fails
* Perhaps, it's should just install the latest one but out of scope for this PR. 
* I've not added a JIRA ticket because it seems unnecessary